### PR TITLE
Upgrade FoundationDB, Scala, SBT and sbt-softwaremill

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: scala
 sudo: true
 scala:
-  - 2.12.6
+  - 2.12.8
 jdk: oraclejdk8
 install:
   - sudo apt-get update
   - sudo apt-get -qq -y install wget
   - sudo apt-get -qq -y install python2.7
   - sudo apt-get -qq -y install python
-  - wget https://www.foundationdb.org/downloads/5.2.5/ubuntu/installers/foundationdb-clients_5.2.5-1_amd64.deb
-  - wget https://www.foundationdb.org/downloads/5.2.5/ubuntu/installers/foundationdb-server_5.2.5-1_amd64.deb
-  - sudo dpkg -i foundationdb-clients_5.2.5-1_amd64.deb foundationdb-server_5.2.5-1_amd64.deb
+  - wget https://www.foundationdb.org/downloads/6.0.15/ubuntu/installers/foundationdb-clients_6.0.15-1_amd64.deb
+  - wget https://www.foundationdb.org/downloads/6.0.15/ubuntu/installers/foundationdb-server_6.0.15-1_amd64.deb
+  - sudo dpkg -i foundationdb-clients_6.0.15-1_amd64.deb foundationdb-server_6.0.15-1_amd64.deb
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION scalafmt::test test:scalafmt::test sbt:scalafmt::test coverage test coverageReport
+  - sbt ++$TRAVIS_SCALA_VERSION test:scalafmt scalafmtSbt coverage test coverageReport
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It aims to be type-safe and idiomatic for Scala.
 
 ```scala
 implicit val ec = scala.concurrent.ExecutionContext.global
-val transactor = Transactor(version = 520)
+val transactor = Transactor(version = 600)
 
 final case class Book(isbn: String, title: String, publishedOn: LocalDate)
 

--- a/akka-streams/src/test/scala/com/github/pwliwanow/foundationdb4s/streams/FoundationDbStreamsSpec.scala
+++ b/akka-streams/src/test/scala/com/github/pwliwanow/foundationdb4s/streams/FoundationDbStreamsSpec.scala
@@ -9,7 +9,7 @@ abstract class FoundationDbStreamsSpec
     extends TestKit(ActorSystemHolder.system)
     with FoundationDbSpec {
   implicit override def ec: ExecutionContextExecutor = system.dispatcher
-  override lazy val testTransactor: Transactor = Transactor(520)(ec)
+  override lazy val testTransactor: Transactor = Transactor(600)(ec)
 }
 
 object ActorSystemHolder {

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ lazy val example = project
 
 lazy val commonSettings = buildSettings ++ Seq(
   organization := "com.github.pwliwanow.foundationdb4s",
-  scalaVersion := "2.12.6",
+  scalaVersion := "2.12.8",
   scalafmtOnCompile := true,
   coverageExcludedPackages := "com.github.pwliwanow.foundationdb4s.example.*",
   releaseProcess := Seq(

--- a/core/src/test/scala/com/github/pwliwanow/foundationdb4s/core/FoundationDbSpec.scala
+++ b/core/src/test/scala/com/github/pwliwanow/foundationdb4s/core/FoundationDbSpec.scala
@@ -20,7 +20,7 @@ trait FoundationDbSpec extends FlatSpecLike with TableDrivenPropertyChecks with 
   implicit def ec: ExecutionContextExecutor = scala.concurrent.ExecutionContext.global
   val subspace = new Subspace(Tuple.from("foundationDbTestSubspace"))
 
-  lazy val testTransactor = Transactor(version = 520)
+  lazy val testTransactor = Transactor(version = 600)
 
   protected val typedSubspace = new TypedSubspace[FriendEntity, FriendKey] {
     override val subspace: Subspace = spec.subspace

--- a/example/src/main/scala/com/github/pwliwanow/foundationdb4s/example/ClassScheduling.scala
+++ b/example/src/main/scala/com/github/pwliwanow/foundationdb4s/example/ClassScheduling.scala
@@ -15,7 +15,7 @@ import scala.util.Random
 
 object ClassScheduling {
   implicit val executor: ExecutionContextExecutor = scala.concurrent.ExecutionContext.global
-  val transactor = Transactor(version = 520)
+  val transactor = Transactor(version = 600)
 
   final case class Attendance(student: String, `class`: Class)
   final case class ClassAvailability(`class`: Class, seatsAvailable: Int)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,8 +11,8 @@ object Dependencies {
   private lazy val cats = "org.typelevel" %% "cats-core" % catsVersion
   private lazy val catsLaws = "org.typelevel" %% "cats-laws" % catsVersion
 
-  private val foundationDbVersion = "5.2.5"
-  private lazy val foundationDb = "org.foundationdb" % "fdb-java" % foundationDbVersion
+  private val foundationDbVersion = "6.0.15"
+  private lazy val foundationDb = "org.foundationdb" % "fdb-java" % foundationDbVersion withSources()
 
   private val java8CompatVersion = "0.9.0"
   private lazy val java8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % java8CompatVersion
@@ -28,7 +28,8 @@ object Dependencies {
 
   private lazy val akkaStreamsTestDependencies: Seq[ModuleID] =
     Seq(akkaStreamsTestKit).map(_ % Test)
-  private lazy val coreTestDependencies: Seq[ModuleID] = Seq(catsLaws, scalaMock, scalaTest).map(_ % Test)
+  private lazy val coreTestDependencies: Seq[ModuleID] =
+    Seq(catsLaws, scalaMock, scalaTest).map(_ % Test)
 
   lazy val allAkkaStreamsDependencies
     : Seq[ModuleID] = akkaStreamsDependencies ++ akkaStreamsTestDependencies

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.2.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.softwaremill.sbt-softwaremill" % "sbt-softwaremill" % "1.3.8")
+addSbtPlugin("com.softwaremill.sbt-softwaremill" % "sbt-softwaremill" % "1.3.17")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")


### PR DESCRIPTION
Resolves #12 and also upgrades all other dependencies. 
FoundationDB: 5.2.5 to **6.0.15** (Jar-file is included since no 6.0-version is available yet on Maven Central).
Scala: 2.12.6 to **2.12.8**.
SBT: 1.1.6 to **1.2.7**.
sbt-softwaremill: 1.3.8 to **1.3.17**.

